### PR TITLE
#11 clickイベントの伝播を途中で止められるとiOSでMMLが再生されない

### DIFF
--- a/project/flmmlonhtml5-raw.js
+++ b/project/flmmlonhtml5-raw.js
@@ -270,13 +270,14 @@ var FlMMLonHTML5 = function () {
     var AudioCtx = window.AudioContext || window.webkitAudioContext;
     FlMMLonHTML5.audioCtx = new AudioCtx();
 
-    // iOS対策
+    // iOS/Chrome向けWeb Audioアンロック処理
     document.addEventListener("DOMContentLoaded", function () {
         window.addEventListener("click", function onClick(e) {
             var audioCtx = FlMMLonHTML5.audioCtx;
             var bufSrcDmy = audioCtx.createBufferSource();
             bufSrcDmy.connect(audioCtx.destination);
             bufSrcDmy.start(0);
+            audioCtx.resume();
             document.removeEventListener("click", onClick);
         }, true);
     });

--- a/project/flmmlonhtml5-raw.js
+++ b/project/flmmlonhtml5-raw.js
@@ -270,15 +270,15 @@ var FlMMLonHTML5 = function () {
     var AudioCtx = window.AudioContext || window.webkitAudioContext;
     FlMMLonHTML5.audioCtx = new AudioCtx();
 
-    // iOS Safari対策
+    // iOS対策
     document.addEventListener("DOMContentLoaded", function () {
-        document.addEventListener("click", function onClick(e) {
+        window.addEventListener("click", function onClick(e) {
             var audioCtx = FlMMLonHTML5.audioCtx;
             var bufSrcDmy = audioCtx.createBufferSource();
             bufSrcDmy.connect(audioCtx.destination);
             bufSrcDmy.start(0);
             document.removeEventListener("click", onClick);
-        });
+        }, true);
     });
     
     return FlMMLonHTML5;


### PR DESCRIPTION
#11 の対応
- iOSで他DOM要素によってclickイベントの伝播を途中で止められても再生できるよう修正
- 将来のChrome (+v66の一部) 用Web Audioのアンロック処理を追加