### PR TITLE
#21 COM_ 系の定数をpublic化

### DIFF
--- a/src/flmmlonhtml5-raw.js
+++ b/src/flmmlonhtml5-raw.js
@@ -3,23 +3,6 @@
 "use strict";
 
 var FlMMLonHTML5 = function () {
-    var BUFFER_SIZE = 8192;
-
-    var COM_BOOT      =  1, // Main->Worker
-        COM_PLAY      =  2, // Main->Worker
-        COM_STOP      =  3, // Main->Worker
-        COM_PAUSE     =  4, // Main->Worker
-        COM_BUFFER    =  5, // Main->Worker->Main
-        COM_COMPCOMP  =  6, // Worker->Main
-        COM_BUFRING   =  7, // Worker->Main
-        COM_COMPLETE  =  8, // Worker->Main
-        COM_SYNCINFO  =  9, // Main->Worker->Main
-        COM_PLAYSOUND = 10, // Worker->Main
-        COM_STOPSOUND = 11, // Worker->Main->Worker
-        COM_DEBUG     = 12; // Worker->Main
-
-    var emptyBuffer = new Float32Array(BUFFER_SIZE);
-
     var divDebug;
 
     function debug(str) {
@@ -60,50 +43,70 @@ var FlMMLonHTML5 = function () {
         this.events = {};
         
         worker.postMessage({
-            type: COM_BOOT,
+            type: FlMMLonHTML5.COM_BOOT,
             sampleRate: FlMMLonHTML5.audioCtx.sampleRate,
-            bufferSize: BUFFER_SIZE
+            bufferSize: FlMMLonHTML5.BUFFER_SIZE
         });
         this.setInfoInterval(125);
     }
 
+    // static
+    extend(FlMMLonHTML5, {
+        BUFFER_SIZE: 8192,
+
+        COM_BOOT     :  1, // Main->Worker
+        COM_PLAY     :  2, // Main->Worker
+        COM_STOP     :  3, // Main->Worker
+        COM_PAUSE    :  4, // Main->Worker
+        COM_BUFFER   :  5, // Main->Worker->Main
+        COM_COMPCOMP :  6, // Worker->Main
+        COM_BUFRING  :  7, // Worker->Main
+        COM_COMPLETE :  8, // Worker->Main
+        COM_SYNCINFO :  9, // Main->Worker->Main
+        COM_PLAYSOUND: 10, // Worker->Main
+        COM_STOPSOUND: 11, // Worker->Main->Worker
+        COM_DEBUG    : 12  // Worker->Main
+    });
+    FlMMLonHTML5.emptyBuffer = new Float32Array(FlMMLonHTML5.BUFFER_SIZE);
+
+    // not static
     extend(FlMMLonHTML5.prototype, {
         onMessage: function (e) {
             var data = e.data,
                 type = data.type;
 
-            //console.log("Main received " + type);
+            // console.log("Main received " + Object.keys(FlMMLonHTML5).filter(k => k.indexOf("COM_") === 0 && FlMMLonHTML5[k] === type));
             switch (type) {
-                case COM_BUFFER:
+                case FlMMLonHTML5.COM_BUFFER:
                     this.buffer = data.buffer;
                     this.bufferReady = true;
                     break;
-                case COM_COMPCOMP:
+                case FlMMLonHTML5.COM_COMPCOMP:
                     extend(this, data.info);
                     this.oncompilecomplete && this.oncompilecomplete();
                     this.trigger("compilecomplete");
                     break;
-                case COM_BUFRING:
+                case FlMMLonHTML5.COM_BUFRING:
                     this.onbuffering && this.onbuffering(data);
                     this.trigger("buffering", data);
                     break;
-                case COM_COMPLETE:
+                case FlMMLonHTML5.COM_COMPLETE:
                     this.oncomplete && this.oncomplete();
                     this.trigger("complete");
                     break;
-                case COM_SYNCINFO:
+                case FlMMLonHTML5.COM_SYNCINFO:
                     extend(this, data.info);
                     this.onsyncinfo && this.onsyncinfo();
                     this.trigger("syncinfo");
                     break;
-                case COM_PLAYSOUND:
+                case FlMMLonHTML5.COM_PLAYSOUND:
                     this.playSound();
                     break;
-                case COM_STOPSOUND:
+                case FlMMLonHTML5.COM_STOPSOUND:
                     this.stopSound(data.isFlushBuf);
-                    this.worker.postMessage({ type: COM_STOPSOUND });
+                    this.worker.postMessage({ type: FlMMLonHTML5.COM_STOPSOUND });
                     break;
-                case COM_DEBUG:
+                case FlMMLonHTML5.COM_DEBUG:
                     debug(data.str);
             }
         },
@@ -117,7 +120,7 @@ var FlMMLonHTML5 = function () {
             gain.gain.value = this.volume / 127.0;
             gain.connect(audioCtx.destination);
 
-            this.scrProc = audioCtx.createScriptProcessor(BUFFER_SIZE, 1, 2);
+            this.scrProc = audioCtx.createScriptProcessor(FlMMLonHTML5.BUFFER_SIZE, 1, 2);
             this.scrProc.addEventListener("audioprocess", this.onAudioProcessBinded);
             this.scrProc.connect(this.gain);
 
@@ -144,11 +147,11 @@ var FlMMLonHTML5 = function () {
                 outBuf.getChannelData(0).set(this.buffer[0]);
                 outBuf.getChannelData(1).set(this.buffer[1]);
                 this.bufferReady = false;
-                this.worker.postMessage({ type: COM_BUFFER, retBuf: this.buffer }, [this.buffer[0].buffer, this.buffer[1].buffer]);
+                this.worker.postMessage({ type: FlMMLonHTML5.COM_BUFFER, retBuf: this.buffer }, [this.buffer[0].buffer, this.buffer[1].buffer]);
             } else {
-                outBuf.getChannelData(0).set(emptyBuffer);
-                outBuf.getChannelData(1).set(emptyBuffer);
-                this.worker.postMessage({ type: COM_BUFFER, retBuf: null });
+                outBuf.getChannelData(0).set(FlMMLonHTML5.emptyBuffer);
+                outBuf.getChannelData(1).set(FlMMLonHTML5.emptyBuffer);
+                this.worker.postMessage({ type: FlMMLonHTML5.COM_BUFFER, retBuf: null });
             }
         },
 
@@ -164,15 +167,15 @@ var FlMMLonHTML5 = function () {
 
 
         play: function (mml) {
-            this.worker.postMessage({ type: COM_PLAY, mml: mml });
+            this.worker.postMessage({ type: FlMMLonHTML5.COM_PLAY, mml: mml });
         },
 
         stop: function () {
-            this.worker.postMessage({ type: COM_STOP });
+            this.worker.postMessage({ type: FlMMLonHTML5.COM_STOP });
         },
 
         pause: function () {
-            this.worker.postMessage({ type: COM_PAUSE });
+            this.worker.postMessage({ type: FlMMLonHTML5.COM_PAUSE });
         },
 
         setMasterVolume: function (volume) {
@@ -229,11 +232,11 @@ var FlMMLonHTML5 = function () {
         },
 
         setInfoInterval: function (interval) {
-            this.worker.postMessage({ type: COM_SYNCINFO, interval: interval });
+            this.worker.postMessage({ type: FlMMLonHTML5.COM_SYNCINFO, interval: interval });
         },
 
         syncInfo: function () {
-            this.worker.postMessage({ type: COM_SYNCINFO, interval: null });
+            this.worker.postMessage({ type: FlMMLonHTML5.COM_SYNCINFO, interval: null });
         },
 
         addEventListener: function (type, listener) {

--- a/src/messenger/Messenger.ts
+++ b/src/messenger/Messenger.ts
@@ -3,20 +3,20 @@
 module messenger {
     import MML = flmml.MML;
 
-    var COM_BOOT      =  1, // Main->Worker
-        COM_PLAY      =  2, // Main->Worker
-        COM_STOP      =  3, // Main->Worker
-        COM_PAUSE     =  4, // Main->Worker
-        COM_BUFFER    =  5, // Main->Worker->Main
-        COM_COMPCOMP  =  6, // Worker->Main
-        COM_BUFRING   =  7, // Worker->Main
-        COM_COMPLETE  =  8, // Worker->Main
-        COM_SYNCINFO  =  9, // Main->Worker->Main
-        COM_PLAYSOUND = 10, // Worker->Main
-        COM_STOPSOUND = 11, // Worker->Main->Worker
-        COM_DEBUG     = 12; // Worker->Main
-
     export class Messenger {
+        static readonly COM_BOOT     : number =  1; // Main->Worker
+        static readonly COM_PLAY     : number =  2; // Main->Worker
+        static readonly COM_STOP     : number =  3; // Main->Worker
+        static readonly COM_PAUSE    : number =  4; // Main->Worker
+        static readonly COM_BUFFER   : number =  5; // Main->Worker->Main
+        static readonly COM_COMPCOMP : number =  6; // Worker->Main
+        static readonly COM_BUFRING  : number =  7; // Worker->Main
+        static readonly COM_COMPLETE : number =  8; // Worker->Main
+        static readonly COM_SYNCINFO : number =  9; // Main->Worker->Main
+        static readonly COM_PLAYSOUND: number = 10; // Worker->Main
+        static readonly COM_STOPSOUND: number = 11; // Worker->Main->Worker
+        static readonly COM_DEBUG    : number = 12; // Worker->Main
+
         mml: MML;
         tIDInfo: number;
         infoInterval: number;
@@ -41,28 +41,28 @@ module messenger {
                 type: number = data.type,
                 mml: MML = this.mml;
 
-            //console.log("Worker received " + type);
+            // console.log("Worker received " + Object.keys(Messenger).filter(k => k.indexOf("COM_") === 0 && Messenger[k] === type));
             switch (type) {
-                case COM_BOOT:
+                case Messenger.COM_BOOT:
                     this.audioSampleRate = data.sampleRate;
                     this.audioBufferSize = data.bufferSize;
                     this.mml = new MML();
                     break;
-                case COM_PLAY:
+                case Messenger.COM_PLAY:
                     mml.play(data.mml);
                     break;
-                case COM_STOP:
+                case Messenger.COM_STOP:
                     mml.stop();
                     this.syncInfo();
                     break;
-                case COM_PAUSE:
+                case Messenger.COM_PAUSE:
                     mml.pause();
                     this.syncInfo();
                     break;
-                case COM_BUFFER:
+                case Messenger.COM_BUFFER:
                     this.onrequestbuffer && this.onrequestbuffer(data);
                     break;
-                case COM_SYNCINFO:
+                case Messenger.COM_SYNCINFO:
                     if (typeof data.interval === "number") {
                         this.infoInterval = data.interval;
                         clearInterval(this.tIDInfo);
@@ -73,21 +73,21 @@ module messenger {
                         this.syncInfo();
                     }
                     break;
-                case COM_STOPSOUND:
+                case Messenger.COM_STOPSOUND:
                     this.onstopsound && this.onstopsound();
                     break;
             }
         }
 
         buffering(progress: number): void {
-            postMessage({ type: COM_BUFRING, progress: progress });
+            postMessage({ type: Messenger.COM_BUFRING, progress: progress });
         }
 
         compileComplete(): void {
             var mml: MML = this.mml;
 
             postMessage({
-                type: COM_COMPCOMP,
+                type: Messenger.COM_COMPCOMP,
                 info: {
                     totalMSec: mml.getTotalMSec(),
                     totalTimeStr: mml.getTotalTimeStr(),
@@ -101,20 +101,20 @@ module messenger {
         }
 
         playSound(): void {
-            postMessage({ type: COM_PLAYSOUND });
+            postMessage({ type: Messenger.COM_PLAYSOUND });
             this.syncInfo();
         }
 
         stopSound(isFlushBuf: boolean = false): void {
-            postMessage({ type: COM_STOPSOUND, isFlushBuf: isFlushBuf });
+            postMessage({ type: Messenger.COM_STOPSOUND, isFlushBuf: isFlushBuf });
         }
 
         sendBuffer(buffer: Array<Float32Array>): void {
-            postMessage({ type: COM_BUFFER, buffer: buffer }, [buffer[0].buffer, buffer[1].buffer]);
+            postMessage({ type: Messenger.COM_BUFFER, buffer: buffer }, [buffer[0].buffer, buffer[1].buffer]);
         }
 
         complete(): void {
-            postMessage({ type: COM_COMPLETE });
+            postMessage({ type: Messenger.COM_COMPLETE });
             this.syncInfo();
         }
 
@@ -123,7 +123,7 @@ module messenger {
 
             this.lastInfoTime = self.performance ? self.performance.now() : new Date().getTime();
             postMessage({
-                type: COM_SYNCINFO,
+                type: Messenger.COM_SYNCINFO,
                 info: {
                     _isPlaying: mml.isPlaying(),
                     _isPaused: mml.isPaused(),
@@ -143,7 +143,7 @@ module messenger {
         }
 
         debug(str: string = ""): void {
-            postMessage({ type: COM_DEBUG, str: str });
+            postMessage({ type: Messenger.COM_DEBUG, str: str });
         }
     }
 }


### PR DESCRIPTION
#21 対応
- `flmmlonhtml5-raw.js`, `Messenger.ts`, `flmmlplayer-raw.js`の`var`宣言されている定数をすべてpublicなstaticフィールド\(相当\)に変更
- `COM_DEBUG` 廃止